### PR TITLE
Bump bdk-ffi to v0.8.0 tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/  
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html  
-[unreleased]: https://github.com/bitcoindevkit/bdk-python/compare/v0.0.5...HEAD  
+[unreleased]: https://github.com/bitcoindevkit/bdk-python/compare/v0.2.0...HEAD  
 [0.0.1-0.0.5]: https://github.com/bitcoindevkit/bdk-python/compare/58f189f987cc644a1d86e965623c8f50904588ad...v0.0.5  
 [0.0.5-0.1.0]: https://github.com/bitcoindevkit/bdk-python/compare/v0.0.5...v0.1.0
 [0.1.0-0.2.0]: https://github.com/bitcoindevkit/bdk-python/compare/v0.1.0...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 
 ## [Unreleased]
 
+## [0.1.0-0.2.0]
+### Added
+- Update BDK to version `0.20.0`
+- APIs Added
+    - TxBuilder.add_data(data)
+    - Wallet.list_unspent() returns a list of local UTXOs
+    - Add coin control methods on TxBuilder
+
+### Fixed
+- Tox tests
+
 ## [0.0.5-0.1.0]
 ### Added
 - Community related files (bug report, feature request, and pull request templates)
@@ -36,3 +47,4 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 [unreleased]: https://github.com/bitcoindevkit/bdk-python/compare/v0.0.5...HEAD  
 [0.0.1-0.0.5]: https://github.com/bitcoindevkit/bdk-python/compare/58f189f987cc644a1d86e965623c8f50904588ad...v0.0.5  
 [0.0.5-0.1.0]: https://github.com/bitcoindevkit/bdk-python/compare/v0.0.5...v0.1.0
+[0.1.0-0.2.0]: https://github.com/bitcoindevkit/bdk-python/compare/v0.1.0...v0.2.0

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ print(f"Wallet balance is: {balance}")
 """
 
 rust_ext = RustExtension(
-    "bdkpython.bdkffi",
+    target="bdkpython.bdkffi",
     path="./bdk-ffi/Cargo.toml",
     binding=Binding.NoBinding,
 )
@@ -60,7 +60,7 @@ rust_ext = RustExtension(
 setup(
     name='bdkpython',
     version='0.2.0.dev0',
-    description="The Python language bindings for the Bitcoin Dev Kit",
+    description="The Python language bindings for the Bitcoin Development Kit",
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/markdown',
     rust_extensions=[rust_ext],


### PR DESCRIPTION
This PR bumps the bdk-ffi submodule to tag `v0.8.0`, updates the changelog, and adds small refactors to the `setup.py` file.