### PR TITLE
Bump bdk-ffi submodule to v0.10.0 (bdk version 0.23.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ python -m unittest --verbose tests/test_bdk.py
 
 ## Build the package
 ```shell
-# Install dependecies
+# Install dependencies
 pip install --requirement requirements.txt
 
 # Generate the bindings first


### PR DESCRIPTION
This PR bumps the bdk-ffi submodule version to `v0.10.0`, which uses bdk `0.23.0`.

## Description
We're fortunate, the tests and example part of the `setup.py` didn't need any changes this time around.

## Checklists
* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)