### PR TITLE
Bump library version to 0.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ rust_ext = RustExtension(
 
 setup(
     name='bdkpython',
-    version='0.3.0.dev0',
+    version='0.4.0',
     description="The Python language bindings for the Bitcoin Development Kit",
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This PR bumps the library version to `0.4.0`, which will be released on PyPI.

## Checklists

## All Submissions:
* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md