### PR TITLE
Add publishing CI workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,5 @@
-name: Build wheels
-on: [push, pull_request]
+name: Build and publish wheels on PyPI
+on: [workflow_dispatch]
 
 # We use manylinux2014 because older CentOS versions used by 2010 and 1 have a very old glibc version, which
 # makes it very hard to use GitHub's javascript actions (checkout, upload-artifact, etc).
@@ -107,3 +107,35 @@ jobs:
         with:
           name: bdkpython-win-${{ matrix.python }}
           path: dist/*.whl
+
+  publish-pypi:
+    name: 'Publish on PyPI'
+    runs-on: ubuntu-latest
+    needs: [build-manylinux2014-x86_64-wheel, build-macos-universal-wheel, build-windows-wheel]
+    # needs: [build-macos-universal-wheel]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      
+      - name: 'Download artifacts in dist/ directory'
+        uses: actions/download-artifact@v2
+        with:
+          path: dist/
+      
+      # - name: Display structure of downloaded files
+      #   run: ls -R
+
+      # - name: 'Publish on test PyPI'
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   with:
+      #     user: __token__
+      #     password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+      #     repository_url: https://test.pypi.org/legacy/
+      #     packages_dir: dist/*/
+
+      - name: 'Publish on PyPI'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages_dir: dist/*/


### PR DESCRIPTION
This PR adds the `publish.yaml` CI workflow which publishes the library on PyPI, and removes that step in the build/test workflow. The new publish workflow requires manual trigger in the Actions tab, the same way we have it in bdk-jvm and bdk-android.

## All Submissions:
* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)