### PR TITLE
Bump library development version to 0.6.0.dev0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ rust_ext = RustExtension(
 
 setup(
     name='bdkpython',
-    version='0.3.0.dev0',
+    version='0.6.0.dev0',
     description="The Python language bindings for the Bitcoin Development Kit",
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This PR bumps the library version in the `setup.py` file to the newest dev version, `0.6.0.dev0`.

Note: we missed 2 updates of those (`0.4.0.dev0` and `0.5.0.dev0`), but they didn't impact anything because the versions in the release branches were always accurate. These are only the versions that appear on the master branch.