### PR TITLE
Add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+The API for this library is developed in the [bdk-ffi](https://github.com/bitcoindevkit/bdk-ffi) repository. Refer to [the changelog there](https://github.com/bitcoindevkit/bdk-ffi/blob/master/CHANGELOG.md) for complete information.


### PR DESCRIPTION
I'm adding a changelog file (which users might expect) that points to the bdk-ffi changelog. This way we don't need to maintain 2 changelogs, and we still have discoverability for people coming across the repo.