### PR TITLE
CI: add trigger tests workflow on bdk-ffi merges

### DIFF
--- a/.github/workflows/test-bdk-ffi-latest.yaml
+++ b/.github/workflows/test-bdk-ffi-latest.yaml
@@ -1,0 +1,285 @@
+name: Test on BDK-FFI Latest Commit
+
+on:
+  push:
+      branches: [ "ci/test-bdk-ffi-latest" ]
+  workflow_dispatch:
+  repository_dispatch:
+    types: [ trigger-bdk-python-test ]
+
+permissions: {}
+
+jobs:
+  test-bdk-ffi-latest-manylinux_2_28-x86_64-wheels:
+    name: "Build and run unittest on Manylinux 2.28 x86_64 wheels against the latest commit on bdk-ffi"
+    runs-on: ubuntu-24.04
+    container:
+      image: quay.io/pypa/manylinux_2_28_x86_64
+      env:
+        PLAT: manylinux_2_28_x86_64
+        PYBIN: "/opt/python/${{ matrix.python }}/bin"
+    strategy:
+      matrix:
+        python:
+          - cp310-cp310
+          - cp311-cp311
+          - cp312-cp312
+          - cp313-cp313
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: "Configure Git safe directory"
+        run: git config --global --add safe.directory /__w/bdk-python/bdk-python
+
+      - name: "Update bdk-ffi submodule to latest"
+        run: |
+          cd ./bdk-ffi/ \
+          && git fetch origin \
+          && git checkout master \
+          && git pull origin master \
+          && echo "Testing commit: $(git log -1 --pretty=format:'%h %s (author: %cn)')"
+
+      - name: "Cache"
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ./target
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+
+      - name: "Install Rust 1.84.1"
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.84.1
+          
+      - name: "Generate bdk.py and binaries"
+        run: bash ./scripts/generate-linux.sh
+
+      - name: "Install build"
+        run: ${PYBIN}/pip install build
+
+      - name: "Build wheel"
+        run: ${PYBIN}/python -m build --wheel --config-setting=--build-option=--plat-name=manylinux_2_28_x86_64 --verbose
+
+      - name: "Install wheel"
+        run: ${PYBIN}/pip install ./dist/*.whl
+
+      - name: "Run tests"
+        run: ${PYBIN}/python -m unittest discover --start "./tests/" --pattern "test_offline_*.py" --verbose
+
+      - name: "Upload artifact test"
+        uses: actions/upload-artifact@v4
+        with:
+          name: bdkpython-manylinux_2_28_x86_64-${{ matrix.python }}
+          path: /home/runner/work/bdk-python/bdk-python/dist/*.whl
+
+  test-bdk-ffi-latest-macos-arm64-wheels:
+    name: "Build and run unittest on macOS arm64 wheels against the latest commit on bdk-ffi"
+    runs-on: macos-13
+    strategy:
+      matrix:
+        python:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          persist-credentials: false
+          fetch-depth: 0
+      
+      - name: "Update bdk-ffi submodule to latest"
+        run: |
+          cd ./bdk-ffi/ \
+          && git fetch origin \
+          && git checkout master \
+          && git pull origin master \
+          && echo "Testing commit: $(git log -1 --pretty=format:'%h %s (author: %cn)')"
+
+      - name: "Cache"
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ./target
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+
+      - name: "Install Python"
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: "Generate bdk.py and binaries"
+        run: bash ./scripts/generate-macos-arm64.sh
+
+      - name: "Install build"
+        run: pip3 install build
+
+      - name: "Build wheel"
+        # Specifying the plat-name argument is necessary to build a wheel with the correct name,
+        # see issue #350 for more information
+        run: python3 -m build --wheel --config-setting=--build-option=--plat-name=macosx_11_0_arm64 --verbose
+
+      # You can't install the arm64 wheel on the CI, so we skip these steps and simply test that the wheel builds
+      # - name: "Install wheel and run tests"
+      #   run: |
+      #     pip3 install ./dist/*.whl
+      #     python3 -m unittest discover --start "./tests/" --pattern "test_offline_*.py" --verbose
+
+      - name: "Upload artifact test"
+        uses: actions/upload-artifact@v4
+        with:
+          name: bdkpython-macos-arm64-${{ matrix.python }}
+          path: /Users/runner/work/bdk-python/bdk-python/dist/*.whl
+
+  test-bdk-ffi-latest-macos-x86_64-wheels:
+    name: "Build and run unittest on macOS x86_64 wheels against the latest commit on bdk-ffi"
+    runs-on: macos-13
+    strategy:
+      matrix:
+        python:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: "Update bdk-ffi submodule to latest"
+        run: |
+          cd ./bdk-ffi/ \
+          && git fetch origin \
+          && git checkout master \
+          && git pull origin master \
+          && echo "Testing commit: $(git log -1 --pretty=format:'%h %s (author: %cn)')"
+
+      - name: "Cache"
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ./target
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: "Generate bdk.py and binaries"
+        run: bash ./scripts/generate-macos-x86_64.sh
+
+      - name: "Install build"
+        run: pip3 install build
+
+      - name: "Build wheel"
+        run: python3 -m build --wheel --config-setting=--build-option=--plat-name=macosx_11_0_x86_64 --verbose
+
+      - name: "Install wheel"
+        run: pip3 install ./dist/*.whl
+
+      - name: "Run tests"
+        run: python3 -m unittest discover --start "./tests/" --pattern "test_offline_*.py" --verbose
+
+      - name: "Upload artifact test"
+        uses: actions/upload-artifact@v4
+        with:
+          name: bdkpython-macos-x86_64-${{ matrix.python }}
+          path: /Users/runner/work/bdk-python/bdk-python/dist/*.whl
+
+  test-bdk-ffi-latest-windows-wheels:
+    name: "Build and run unittest on Windows wheels against the latest commit on bdk-ffi"
+    runs-on: windows-2022
+    strategy:
+      matrix:
+        python:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: "Update bdk-ffi submodule to latest"
+        run: |
+          cd ./bdk-ffi/; 
+          git fetch origin; 
+          git checkout master; 
+          git pull origin master; 
+          echo "Testing commit: $(git log -1 --pretty=format:'%h %s (author: %cn)')"
+
+      - name: "Cache"
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ./target
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+      
+      - name: "Install Python"
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: "Generate bdk.py and binaries"
+        run: bash ./scripts/generate-windows.sh
+
+      - name: "Install build"
+        run: pip install build
+
+      - name: "Build wheel"
+        run: python -m build --wheel --verbose
+
+      - name: "Upload artifact test"
+        uses: actions/upload-artifact@v4
+        with:
+          name: bdkpython-windows-${{ matrix.python }}
+          path: D:\a\bdk-python\bdk-python\dist\*.whl
+
+      - name: "Install dependencies"
+        run: Get-ChildItem 'D:\a\bdk-python\bdk-python\dist\*.whl' | ForEach-Object {pip install $_.FullName}
+        shell: powershell
+
+      - name: "Run tests"
+        run: python -m unittest discover --start "./tests/" --pattern "test_offline_*.py" --verbose
+
+  ruff:
+    name: "Lint tests"
+    runs-on: ubuntu-24.04
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: "Configure Git safe directory"
+        run: git config --global --add safe.directory /__w/bdk-python/bdk-python
+
+      - name: "Install Ruff"
+        run: curl -LsSf https://astral.sh/ruff/install.sh | sh
+
+      - name: "Lint test targets"
+        run: ruff check ./tests/

--- a/.github/workflows/test-bdk-ffi-latest.yaml
+++ b/.github/workflows/test-bdk-ffi-latest.yaml
@@ -81,7 +81,7 @@ jobs:
 
   test-bdk-ffi-latest-macos-arm64-wheels:
     name: "Build and run unittest on macOS arm64 wheels against the latest commit on bdk-ffi"
-    runs-on: macos-13
+    runs-on: macos-14
     strategy:
       matrix:
         python:
@@ -130,11 +130,10 @@ jobs:
         # see issue #350 for more information
         run: python3 -m build --wheel --config-setting=--build-option=--plat-name=macosx_11_0_arm64 --verbose
 
-      # You can't install the arm64 wheel on the CI, so we skip these steps and simply test that the wheel builds
-      # - name: "Install wheel and run tests"
-      #   run: |
-      #     pip3 install ./dist/*.whl
-      #     python3 -m unittest discover --start "./tests/" --pattern "test_offline_*.py" --verbose
+      - name: "Install wheel and run tests"
+        run: |
+          pip3 install ./dist/*.whl
+          python3 -m unittest discover --start "./tests/" --pattern "test_offline_*.py" --verbose
 
       - name: "Upload artifact test"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test-bdk-ffi-latest.yaml
+++ b/.github/workflows/test-bdk-ffi-latest.yaml
@@ -51,10 +51,10 @@ jobs:
             ./target
           key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
 
-      - name: "Install Rust 1.84.1"
-        uses: actions-rs/toolchain@v1
+      - name: "Setup Rust"
+        uses: actions-rust-lang/setup-rust-toolchain@v1.15.0
         with:
-          toolchain: 1.84.1
+          toolchain: 1.85.1
           
       - name: "Generate bdk.py and binaries"
         run: bash ./scripts/generate-linux.sh
@@ -70,12 +70,6 @@ jobs:
 
       - name: "Run tests"
         run: ${PYBIN}/python -m unittest discover --start "./tests/" --pattern "test_offline_*.py" --verbose
-
-      - name: "Upload artifact test"
-        uses: actions/upload-artifact@v4
-        with:
-          name: bdkpython-manylinux_2_28_x86_64-${{ matrix.python }}
-          path: /home/runner/work/bdk-python/bdk-python/dist/*.whl
 
   test-bdk-ffi-latest-macos-arm64-wheels:
     name: "Build and run unittest on macOS arm64 wheels against the latest commit on bdk-ffi"
@@ -134,12 +128,6 @@ jobs:
       - name: "Run tests"
         run: python3 -m unittest discover --start "./tests/" --pattern "test_offline_*.py" --verbose
 
-      - name: "Upload artifact test"
-        uses: actions/upload-artifact@v4
-        with:
-          name: bdkpython-macos-arm64-${{ matrix.python }}
-          path: /Users/runner/work/bdk-python/bdk-python/dist/*.whl
-
   test-bdk-ffi-latest-macos-x86_64-wheels:
     name: "Build and run unittest on macOS x86_64 wheels against the latest commit on bdk-ffi"
     runs-on: macos-15-intel
@@ -194,12 +182,6 @@ jobs:
       - name: "Run tests"
         run: python3 -m unittest discover --start "./tests/" --pattern "test_offline_*.py" --verbose
 
-      - name: "Upload artifact test"
-        uses: actions/upload-artifact@v4
-        with:
-          name: bdkpython-macos-x86_64-${{ matrix.python }}
-          path: /Users/runner/work/bdk-python/bdk-python/dist/*.whl
-
   test-bdk-ffi-latest-windows-wheels:
     name: "Build and run unittest on Windows wheels against the latest commit on bdk-ffi"
     runs-on: windows-2022
@@ -248,12 +230,6 @@ jobs:
 
       - name: "Build wheel"
         run: python -m build --wheel --verbose
-
-      - name: "Upload artifact test"
-        uses: actions/upload-artifact@v4
-        with:
-          name: bdkpython-windows-${{ matrix.python }}
-          path: D:\a\bdk-python\bdk-python\dist\*.whl
 
       - name: "Install dependencies"
         run: Get-ChildItem 'D:\a\bdk-python\bdk-python\dist\*.whl' | ForEach-Object {pip install $_.FullName}

--- a/.github/workflows/test-bdk-ffi-latest.yaml
+++ b/.github/workflows/test-bdk-ffi-latest.yaml
@@ -1,8 +1,6 @@
 name: Test on BDK-FFI Latest Commit
 
 on:
-  push:
-      branches: [ "ci/test-bdk-ffi-latest" ]
   workflow_dispatch:
   repository_dispatch:
     types: [ trigger-bdk-python-test ]

--- a/.github/workflows/test-bdk-ffi-latest.yaml
+++ b/.github/workflows/test-bdk-ffi-latest.yaml
@@ -130,10 +130,11 @@ jobs:
         # see issue #350 for more information
         run: python3 -m build --wheel --config-setting=--build-option=--plat-name=macosx_11_0_arm64 --verbose
 
-      - name: "Install wheel and run tests"
-        run: |
-          pip3 install ./dist/*.whl
-          python3 -m unittest discover --start "./tests/" --pattern "test_offline_*.py" --verbose
+      - name: "Install wheel"
+        run: pip3 install ./dist/*.whl
+          
+      - name: "Run tests"
+        run: python3 -m unittest discover --start "./tests/" --pattern "test_offline_*.py" --verbose
 
       - name: "Upload artifact test"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test-bdk-ffi-latest.yaml
+++ b/.github/workflows/test-bdk-ffi-latest.yaml
@@ -142,7 +142,7 @@ jobs:
 
   test-bdk-ffi-latest-macos-x86_64-wheels:
     name: "Build and run unittest on macOS x86_64 wheels against the latest commit on bdk-ffi"
-    runs-on: macos-13
+    runs-on: macos-15-intel
     strategy:
       matrix:
         python:


### PR DESCRIPTION
### Description

This PR adds a workflow that handles trigger event `trigger-bdk-python-test` when new commits are merged into the master branch of bdk-ffi.

Fixes https://github.com/bitcoindevkit/bdk-python/issues/17

### Notes to the reviewers

This PR is linked to [bdk-ffi PR](https://github.com/bitcoindevkit/bdk-ffi/pull/868).

TODO (Repository owner): 

- create Personal Access Token (classic) with permissions for workflow and repo (i guess we could include only public_repo). 
The token's value must be added as repo secret into the bdk-ffi repo.

### Checklists

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [X] I'm linking the issue being fixed by this PR