### PR TITLE
chore: Prefer uv over pip for dependencies

### DIFF
--- a/scripts/generate-linux.sh
+++ b/scripts/generate-linux.sh
@@ -8,7 +8,15 @@ printf "Submodule is checked out at commit: $(git submodule status)\n\n"
 
 echo "Setting up Python dependencies..."
 ${PYBIN}/python --version
-${PYBIN}/pip install -r requirements.txt
+
+# Check for uv first (faster), then fall back to pip
+if command -v uv &> /dev/null; then
+    echo "Using uv to install dependencies..."
+    uv add -r requirements.txt
+else
+    echo "Using pip to install dependencies..."
+    ${PYBIN}/pip install -r requirements.txt || ${PYBIN}/pip3 install -r requirements.txt
+fi
 
 cd ./bdk-ffi/bdk-ffi/
 

--- a/scripts/generate-macos-arm64.sh
+++ b/scripts/generate-macos-arm64.sh
@@ -8,7 +8,15 @@ printf "Submodule is checked out at commit: $(git submodule status)\n\n"
 
 echo "Setting up Python dependencies..."
 python3 --version
-pip install -r requirements.txt
+
+# Check for uv first (faster), then fall back to pip
+if command -v uv &> /dev/null; then
+    echo "Using uv to install dependencies..."
+    uv add -r requirements.txt
+else
+    echo "Using pip to install dependencies..."
+    pip install -r requirements.txt || pip3 install -r requirements.txt
+fi
 
 cd ./bdk-ffi/bdk-ffi/
 

--- a/scripts/generate-macos-x86_64.sh
+++ b/scripts/generate-macos-x86_64.sh
@@ -8,7 +8,15 @@ printf "Submodule is checked out at commit: $(git submodule status)\n\n"
 
 echo "Setting up Python dependencies..."
 python3 --version
-pip install -r requirements.txt
+
+# Check for uv first (faster), then fall back to pip
+if command -v uv &> /dev/null; then
+    echo "Using uv to install dependencies..."
+    uv add -r requirements.txt
+else
+    echo "Using pip to install dependencies..."
+    pip install -r requirements.txt || pip3 install -r requirements.txt
+fi
 
 cd ./bdk-ffi/bdk-ffi/
 

--- a/scripts/generate-windows.sh
+++ b/scripts/generate-windows.sh
@@ -8,7 +8,15 @@ printf "Submodule is checked out at commit: $(git submodule status)\n\n"
 
 echo "Setting up Python dependencies..."
 python3 --version
-pip install -r requirements.txt
+
+# Check for uv first (faster), then fall back to pip
+if command -v uv &> /dev/null; then
+    echo "Using uv to install dependencies..."
+    uv add -r requirements.txt
+else 
+    echo "Using pip to install dependencies..."
+    pip install -r requirements.txt || pip3 install -r requirements.txt
+fi
 
 cd ./bdk-ffi/bdk-ffi/
 


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Alter the scripts for preferring `uv` over `pip`, if it's available. Also tries `pip3` if `pip` is not available.
`uv` is the modern way to manage dependencies on python, it's faster than the alternatives and written on rust.
Closes https://github.com/bitcoindevkit/bdk-python/issues/26

### Checklists

#### All Submissions:

* [X] I've signed all my commits
* [X] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
~~[ ] I ran `cargo fmt` and `cargo clippy` before committing~~