### PR TITLE
build: remove dead dependencies from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-semantic-version==2.9.0
-typing_extensions==4.0.1
 setuptools==75.3.2
 wheel==0.38.4
 build==1.3.0


### PR DESCRIPTION
## Summary
- Remove `semantic-version` from `requirements.txt`
- Remove `typing_extensions` from `requirements.txt`

## Why
These packages are not referenced by the current codebase and are no longer needed in build/bootstrap requirements.

## Validation
- Searched the repository for direct references to `semantic-version` and `typing_extensions`
- Confirmed this branch differs from `master` by a single commit that only updates `requirements.txt`