### PR TITLE
ci: bump GitHub Actions to v5

### DIFF
--- a/.github/workflows/publish-python.yaml
+++ b/.github/workflows/publish-python.yaml
@@ -21,7 +21,7 @@ jobs:
           - cp313-cp313
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           persist-credentials: false
@@ -44,7 +44,7 @@ jobs:
         # see issue #350 for more information
         run: UV_PYTHON=${PYBIN}/python uv build --wheel --config-setting=--build-option=--plat-name=manylinux_2_28_x86_64 --verbose
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: bdkpython-manylinux_2_28_x86_64-${{ matrix.python }}
           path: dist/*.whl
@@ -61,14 +61,14 @@ jobs:
           - "3.13"
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           persist-credentials: false
           fetch-depth: 0
 
       - name: "Install Python"
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 
@@ -87,7 +87,7 @@ jobs:
         run: uv build --wheel --config-setting=--build-option=--plat-name=macosx_11_0_arm64 --verbose
 
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: bdkpython-macos-arm64-${{ matrix.python }}
           path: dist/*.whl
@@ -104,14 +104,14 @@ jobs:
           - "3.13"
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           persist-credentials: false
           fetch-depth: 0
 
       - name: "Install Python"
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 
@@ -129,7 +129,7 @@ jobs:
         # see issue #350 for more information
         run: uv build --wheel --config-setting=--build-option=--plat-name=macosx_11_0_x86_64 --verbose
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: bdkpython-macos-x86_64-${{ matrix.python }}
           path: dist/*.whl
@@ -146,13 +146,13 @@ jobs:
           - "3.13"
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           persist-credentials: false
           fetch-depth: 0
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 
@@ -169,7 +169,7 @@ jobs:
         run: uv build --wheel --verbose
 
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: bdkpython-win-${{ matrix.python }}
           path: dist/*.whl
@@ -180,12 +180,12 @@ jobs:
     needs: [build-manylinux_2_28-x86_64-wheels, build-macos-arm64-wheels, build-macos-x86_64-wheels, build-windows-wheels]
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 
       - name: "Download artifacts in dist/ directory"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: dist/
 

--- a/.github/workflows/python-api-docs.yaml
+++ b/.github/workflows/python-api-docs.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           persist-credentials: false
@@ -50,7 +50,7 @@ jobs:
         run: uv run python -m sphinx -b html -W --keep-going docs/source docs/_build/html
 
       - name: "Upload API Docs"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: artifact-bdkpython-api-docs
           path: docs/_build/html
@@ -70,4 +70,4 @@ jobs:
     steps:
       - name: "Deploy to GitHub Pages"
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/test-bdk-ffi-latest.yaml
+++ b/.github/workflows/test-bdk-ffi-latest.yaml
@@ -25,7 +25,7 @@ jobs:
           - cp313-cp313
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           persist-credentials: false
@@ -81,7 +81,7 @@ jobs:
           - "3.13"
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           persist-credentials: false
@@ -102,7 +102,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: "Install Python"
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 
@@ -132,7 +132,7 @@ jobs:
           - "3.13"
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           persist-credentials: false
@@ -152,7 +152,7 @@ jobs:
       - name: "Set up Rust"
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 
@@ -180,7 +180,7 @@ jobs:
           - "3.13"
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           persist-credentials: false
@@ -201,7 +201,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: "Install Python"
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 
@@ -223,7 +223,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           persist-credentials: false

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -23,7 +23,7 @@ jobs:
           - cp313-cp313
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           persist-credentials: false
@@ -51,7 +51,7 @@ jobs:
         run: ${PYBIN}/python -m unittest discover --start "./tests/" --pattern "test_offline_*.py" --verbose
 
       - name: "Upload artifact test"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: bdkpython-manylinux_2_28_x86_64-${{ matrix.python }}
           path: dist/*.whl
@@ -68,14 +68,14 @@ jobs:
           - "3.13"
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           persist-credentials: false
           fetch-depth: 0
 
       - name: "Install Python"
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 
@@ -99,7 +99,7 @@ jobs:
           python3 -m unittest discover --start "./tests/" --pattern "test_offline_*.py" --verbose
 
       - name: "Upload artifact test"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: bdkpython-macos-arm64-${{ matrix.python }}
           path: dist/*.whl
@@ -116,13 +116,13 @@ jobs:
           - "3.13"
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           persist-credentials: false
           fetch-depth: 0
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 
@@ -145,7 +145,7 @@ jobs:
         run: python3 -m unittest discover --start "./tests/" --pattern "test_offline_*.py" --verbose
 
       - name: "Upload artifact test"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: bdkpython-macos-x86_64-${{ matrix.python }}
           path: dist/*.whl
@@ -162,14 +162,14 @@ jobs:
           - "3.13"
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           persist-credentials: false
           fetch-depth: 0
 
       - name: "Install Python"
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 
@@ -186,7 +186,7 @@ jobs:
         run: uv build --wheel --verbose
 
       - name: "Upload artifact test"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: bdkpython-windows-${{ matrix.python }}
           path: dist/*.whl
@@ -203,7 +203,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           persist-credentials: false


### PR DESCRIPTION
Standardize workflow action references from `@v4` to `@v5`.

Closes #33