### PR TITLE
feat(python): add wallet setup example for bdk-ffi#818

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ uv pip install ./dist/bdkpython-<yourversion>.whl --force-reinstall
 uv run python -m unittest --verbose
 ```
 
+## Examples
+
+This repository includes small offline examples that mirror the JVM binding examples in [bdk-jvm](https://github.com/bitcoindevkit/bdk-jvm/tree/master/examples/src/main/kotlin).
+
+After installing the library locally (see [Local Testing and Usage](#local-testing-and-usage)), run:
+
+```sh
+uv run python examples/wallet_setup_bip32.py
+```
+
+`wallet_setup_bip32.py` demonstrates creating a BIP84 wallet from a fixed sample mnemonic, revealing external and internal addresses, and printing the wallet balance. It runs offline and does not require a Bitcoin node or Esplora server. The mnemonic is for demonstration only and must not be used for real funds.
+
 ## Build HTML API Documentation (Optional)
 
 6. Generate docs

--- a/examples/wallet_setup_bip32.py
+++ b/examples/wallet_setup_bip32.py
@@ -1,0 +1,56 @@
+"""Offline wallet setup example mirroring bdk-jvm WalletSetupBip32."""
+
+from bdkpython import Descriptor
+from bdkpython import DescriptorSecretKey
+from bdkpython import KeychainKind
+from bdkpython import Mnemonic
+from bdkpython import Network
+from bdkpython import NetworkKind
+from bdkpython import Persister
+from bdkpython import Wallet
+
+# Sample/dev mnemonic only. Never use this for real funds.
+SAMPLE_MNEMONIC = (
+    "space echo position wrist orient erupt relief museum myself grain wisdom tumble"
+)
+
+
+def main() -> None:
+    print("WARNING: This example uses a fixed sample mnemonic for demonstration only.")
+    print("Do not use this mnemonic for real funds.")
+    print(f"Sample mnemonic: {SAMPLE_MNEMONIC}")
+
+    mnemonic = Mnemonic.from_string(SAMPLE_MNEMONIC)
+    descriptor_secret_key = DescriptorSecretKey(NetworkKind.TEST, mnemonic, None)
+    print(f"BIP32 root key: {descriptor_secret_key}")
+
+    external_descriptor = Descriptor.new_bip84(
+        descriptor_secret_key,
+        KeychainKind.EXTERNAL,
+        NetworkKind.TEST,
+    )
+    internal_descriptor = Descriptor.new_bip84(
+        descriptor_secret_key,
+        KeychainKind.INTERNAL,
+        NetworkKind.TEST,
+    )
+    print(f"External descriptor: {external_descriptor}")
+    print(f"Internal descriptor: {internal_descriptor}")
+
+    persister = Persister.new_in_memory()
+    wallet = Wallet(
+        external_descriptor,
+        internal_descriptor,
+        Network.REGTEST,
+        persister,
+    )
+
+    external_address = wallet.reveal_next_address(KeychainKind.EXTERNAL).address
+    internal_address = wallet.reveal_next_address(KeychainKind.INTERNAL).address
+    print(f"External address: {external_address}")
+    print(f"Internal address: {internal_address}")
+    print(f"Balance: {wallet.balance().total.to_sat()} sats")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_offline_examples.py
+++ b/tests/test_offline_examples.py
@@ -1,0 +1,43 @@
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLE_PATH = REPO_ROOT / "examples" / "wallet_setup_bip32.py"
+
+EXPECTED_LABELS = [
+    "WARNING",
+    "Sample mnemonic:",
+    "BIP32 root key:",
+    "External descriptor:",
+    "Internal descriptor:",
+    "External address:",
+    "Internal address:",
+    "Balance:",
+]
+
+
+class OfflineExamplesTest(unittest.TestCase):
+    def test_wallet_setup_bip32_example_runs(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(EXAMPLE_PATH)],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(
+            0,
+            result.returncode,
+            msg=f"Example failed.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+
+        for label in EXPECTED_LABELS:
+            self.assertIn(label, result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Description

Adds a minimal offline Python wallet setup example for the Python portion of [bitcoindevkit/bdk-ffi#818](https://github.com/bitcoindevkit/bdk-ffi/issues/818).

Changes:
- Add `examples/wallet_setup_bip32.py`, mirroring the JVM `WalletSetupBip32` example
- Add `tests/test_offline_examples.py` to run the example and verify stable output labels
- Document how to run the example in `README.md`

The example demonstrates:
- creating a BIP84 wallet from a fixed sample mnemonic
- revealing external and internal addresses
- printing the wallet balance

It runs fully offline and does not require a Bitcoin node, Esplora server, or external funding.

### Notes to the reviewers

- This PR intentionally addresses only the Python examples slice of #818, not all bindings.
- Scope is kept small to avoid the maintenance burden discussed in the closed Swift examples PR ([bdk-ffi#981](https://github.com/bitcoindevkit/bdk-ffi/pull/981)).
- The example uses a fixed sample/dev mnemonic with explicit warnings; it must not be used for real funds.
- Multisig and Kyoto examples were intentionally not included because they require external regtest infrastructure and more ongoing maintenance.
- No CI workflow changes were made in this PR.

### Changelog notice

- Added an offline `wallet_setup_bip32.py` example and README instructions for running it.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran the relevant local checks for this Python repo before committing
<img width="1917" height="693" alt="image" src="https://github.com/user-attachments/assets/f9790391-f62e-43ff-ac1c-99cf239f06b4" />

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR

Closes bitcoindevkit/bdk-ffi#818 only in the Python-examples sense; the umbrella issue may remain open for other bindings.